### PR TITLE
fix: Cases where input.form is not present

### DIFF
--- a/projects/autocomplete/package.json
+++ b/projects/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-input-autocomplete",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Angular input auto complete",
   "repository": {
     "type": "git",

--- a/projects/autocomplete/src/lib/autocomplete.component.ts
+++ b/projects/autocomplete/src/lib/autocomplete.component.ts
@@ -13,6 +13,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  AfterViewInit,
   Output,
   SimpleChange,
   ViewContainerRef,
@@ -245,7 +246,7 @@ export class AutocompleteComponent implements OnInit, OnChanges {
   // tslint:disable-next-line
   selector: '[input-autocomplete]'
 })
-export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges {
+export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges, AfterViewInit {
   @Input() config: any;
   @Input() items: any;
   @Input() ngModel: string;
@@ -265,12 +266,6 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges {
     public viewContainerRef: ViewContainerRef
   ) {
     this.thisElement = this.viewContainerRef.element.nativeElement;
-    const input = this.getInputElement();
-    if (input.form) {
-      input.form.addEventListener('reset', () => {
-        this.reset = true;
-      });
-    }
   }
 
   ngOnInit() {
@@ -293,6 +288,15 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges {
       const component = this.componentRef.instance;
       component.items = changes['items'].currentValue;
       component.filterItems(component.value);
+    }
+  }
+
+  ngAfterViewInit() {
+    const input = this.getInputElement();
+    if (input.form) {
+      input.form.addEventListener('reset', () => {
+        this.reset = true;
+      });
     }
   }
 

--- a/projects/autocomplete/src/lib/autocomplete.component.ts
+++ b/projects/autocomplete/src/lib/autocomplete.component.ts
@@ -266,9 +266,11 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges {
   ) {
     this.thisElement = this.viewContainerRef.element.nativeElement;
     const input = this.getInputElement();
-    input.form.addEventListener('reset', () => {
-      this.reset = true;
-    });
+    if (input.form) {
+      input.form.addEventListener('reset', () => {
+        this.reset = true;
+      });
+    }
   }
 
   ngOnInit() {


### PR DESCRIPTION
This PR fixes an issue where if a form is not present using the autocomplete will fail with the error "cannot read addEventListener of null".

Related to #17