### PR TITLE
Add control prop for reactive forms

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -120,6 +120,8 @@ export class AppComponent  {
 }
 ```
 
+Note: If you're using reactive forms pass the `FormControl` into the input for methods such as `setValue` or `reset` to work.
+
 ## Development
 
 ```bash

--- a/README.MD
+++ b/README.MD
@@ -120,7 +120,7 @@ export class AppComponent  {
 }
 ```
 
-Note: If you're using reactive forms pass the `FormControl` into the input for methods such as `setValue` or `reset` to work.
+**Note:** If you're using reactive forms, pass the `FormControl` into the input as a prop like `<input input-autocomplete [control]="formControl">` for methods such as `setValue` or `reset` to work.
 
 ## Development
 

--- a/projects/autocomplete/package.json
+++ b/projects/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-input-autocomplete",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Angular input auto complete",
   "repository": {
     "type": "git",

--- a/projects/autocomplete/src/lib/autocomplete.component.ts
+++ b/projects/autocomplete/src/lib/autocomplete.component.ts
@@ -19,6 +19,7 @@ import {
   ViewContainerRef,
   HostBinding
 } from '@angular/core';
+import {FormControl} from '@angular/forms';
 
 @Component({
   // tslint:disable-next-line
@@ -250,6 +251,7 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges, Afte
   @Input() config: any;
   @Input() items: any;
   @Input() ngModel: string;
+  @Input() control: FormControl;
   @Output() ngModelChange = new EventEmitter();
   @Output() inputChangedEvent = new EventEmitter();
   @Output() selectEvent = new EventEmitter();
@@ -259,7 +261,7 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges, Afte
   private autocompleteElement: HTMLElement;
   private inputElement: HTMLInputElement;
   private tabIndex: number;
-  private reset: boolean = false;
+  private reset = false;
 
   constructor(
     private resolver: ComponentFactoryResolver,
@@ -293,6 +295,12 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges, Afte
 
   ngAfterViewInit() {
     const input = this.getInputElement();
+    if (this.control) {
+      this.control.valueChanges.subscribe(() => {
+        console.log('value changed');
+        this.reset = true;
+      });
+    }
     if (input.form) {
       input.form.addEventListener('reset', () => {
         this.reset = true;

--- a/projects/autocomplete/src/lib/autocomplete.component.ts
+++ b/projects/autocomplete/src/lib/autocomplete.component.ts
@@ -297,7 +297,6 @@ export class AutocompleteDirective implements OnInit, OnDestroy, OnChanges, Afte
     const input = this.getInputElement();
     if (this.control) {
       this.control.valueChanges.subscribe(() => {
-        console.log('value changed');
         this.reset = true;
       });
     }


### PR DESCRIPTION
This PR adds a `control` prop to the `input-autocomplete` directive.

Currently, using reactive forms it's not possible to programmatically update the value of the input as you would expect.

For example, using `this.formGroup.controls.formControl.setValue('')` will not update the `AutocompletComponent` it will only update the original input underneath it.

With this update if you're using reactive forms, you can now pass the `FormControl` into the input as a prop like `<input input-autocomplete [control]="formControl">` for FormControl methods such as `setValue` or `reset` to work.